### PR TITLE
Allow for execution of ws commands via CommandBlock.

### DIFF
--- a/src/main/java/com/github/websend/Main.java
+++ b/src/main/java/com/github/websend/Main.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.bukkit.Server;
+import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
@@ -167,7 +168,7 @@ public class Main extends JavaPlugin {
                logger.log(Level.SEVERE, "Failed to construct URL from config.", ex);
                 return true;
             }
-            if (sender instanceof ConsoleCommandSender || sender instanceof RemoteConsoleCommandSender) {
+            if (sender instanceof ConsoleCommandSender || sender instanceof RemoteConsoleCommandSender || sender instanceof BlockCommandSender) {
                 POSTRequest request = new POSTRequest(url, args, "@Console", false);
                 requestThreadPool.doRequest(request);
                 return true;


### PR DESCRIPTION
Theoretically this simple change should allow for `/ws` commands to run via CommandBlock. However, this is untested because when I would compile, I'd get strange errors in-game that would prevent commands from being run at all. I probably don't have the right dependencies or didn't compile it correctly. @Waterflames can you check to see if this will work?

Edit: Confirmed that the console now spits out errors when attempting to run a command from a CommandBlock. I don't think I compiled the plugin correctly, which is causing my version to error-out.